### PR TITLE
fix: export package.json required by react-native and bundlers like rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "Store information about any JS value in a side channel. Uses WeakMap if available.",
 	"main": "index.js",
 	"exports": {
+		"./package.json": "./package.json",
 		".": [
 			{
 				"default": "./index.js"


### PR DESCRIPTION
As per this issue in [uuid](https://github.com/uuidjs/uuid/issues/444) references to 'package.json' will break some bundlers like rollup and react native. 

`uuid` fixed [this already in a new version](https://github.com/uuidjs/uuid/commit/be1c8fe9a3206c358e0059b52fafd7213aa48a52).

This PR does the same for `side-channel` although it's much simpler to fix in this case. AFAIK, `package.json` is  only used in a package script and so a reference in exports seems to be enough (tested with rollup)