### PR TITLE
remove most dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ insert_final_newline = true
 indent_style = tab
 indent_size = 2
 trim_trailing_whitespace = true
+block_comment_start = /*
+block_comment = *
+block_comment_end = */

--- a/index.js
+++ b/index.js
@@ -8,15 +8,7 @@ var $Map = typeof Map === 'undefined' ? undefined : Map;
 
 var $bind = Function.prototype.bind;
 var $call = Function.prototype.call;
-var uncurryThis = $bind
-	? $bind.bind($call)
-	// @ts-ignore
-	: function uncurryThis(f) {
-		return function () {
-			// @ts-ignore
-			return $call.apply(f, arguments);
-		};
-	};
+var uncurryThis = $bind ? $bind.bind($call) : undefined;
 
 /**
  * @template {(this: unknown, ...args: any[]) => unknown} T
@@ -29,7 +21,7 @@ var $weakMapGet;
 var $weakMapSet;
 /** @type {UncurryThis<WeakMap<any, any>['has']>} */
 var $weakMapHas;
-if ($WeakMap) {
+if ($WeakMap && uncurryThis) {
 	$weakMapGet = uncurryThis($WeakMap.prototype.get);
 	$weakMapSet = uncurryThis($WeakMap.prototype.set);
 	$weakMapHas = uncurryThis($WeakMap.prototype.has);
@@ -41,7 +33,7 @@ var $mapGet;
 var $mapSet;
 /** @type {UncurryThis<Map<any, any>['has']>} */
 var $mapHas;
-if ($Map) {
+if ($Map && uncurryThis) {
 	$mapGet = uncurryThis($Map.prototype.get);
 	$mapSet = uncurryThis($Map.prototype.set);
 	$mapHas = uncurryThis($Map.prototype.has);

--- a/index.js
+++ b/index.js
@@ -16,10 +16,10 @@ var $mapSet = callBound('Map.prototype.set', true);
 var $mapHas = callBound('Map.prototype.has', true);
 
 /*
-* This function traverses the list returning the node corresponding to the given key.
-*
-* That node is also moved to the head of the list, so that if it's accessed again we don't need to traverse the whole list. By doing so, all the recently used nodes can be accessed relatively quickly.
-*/
+ * This function traverses the list returning the node corresponding to the given key.
+ *
+ * That node is also moved to the head of the list, so that if it's accessed again we don't need to traverse the whole list. By doing so, all the recently used nodes can be accessed relatively quickly.
+ */
 /** @type {import('.').listGetNode} */
 var listGetNode = function (list, key) { // eslint-disable-line consistent-return
 	/** @type {typeof list | NonNullable<(typeof list)['next']>} */

--- a/index.js
+++ b/index.js
@@ -1,19 +1,43 @@
 'use strict';
 
-var GetIntrinsic = require('get-intrinsic');
-var callBound = require('call-bind/callBound');
 var inspect = require('object-inspect');
 
-var $TypeError = require('es-errors/type');
-var $WeakMap = GetIntrinsic('%WeakMap%', true);
-var $Map = GetIntrinsic('%Map%', true);
+var $TypeError = TypeError;
+var $WeakMap = typeof WeakMap === 'undefined' ? undefined : WeakMap;
+var $Map = typeof Map === 'undefined' ? undefined : Map;
 
-var $weakMapGet = callBound('WeakMap.prototype.get', true);
-var $weakMapSet = callBound('WeakMap.prototype.set', true);
-var $weakMapHas = callBound('WeakMap.prototype.has', true);
-var $mapGet = callBound('Map.prototype.get', true);
-var $mapSet = callBound('Map.prototype.set', true);
-var $mapHas = callBound('Map.prototype.has', true);
+var $bind = Function.prototype.bind;
+var $call = Function.prototype.call;
+var uncurryThis = $bind.bind($call);
+
+/**
+ * @template {(this: unknown, ...args: any[]) => unknown} T
+ * @typedef {(self: ThisParameterType<T>, ...args: Parameters<T>) => ReturnType<T>} UncurryThis
+ */
+
+/** @type {UncurryThis<WeakMap<any, any>['get']>} */
+var $weakMapGet;
+/** @type {UncurryThis<WeakMap<any, any>['set']>} */
+var $weakMapSet;
+/** @type {UncurryThis<WeakMap<any, any>['has']>} */
+var $weakMapHas;
+if ($WeakMap) {
+	$weakMapGet = uncurryThis($WeakMap.prototype.get);
+	$weakMapSet = uncurryThis($WeakMap.prototype.set);
+	$weakMapHas = uncurryThis($WeakMap.prototype.has);
+}
+
+/** @type {UncurryThis<Map<any, any>['get']>} */
+var $mapGet;
+/** @type {UncurryThis<Map<any, any>['set']>} */
+var $mapSet;
+/** @type {UncurryThis<Map<any, any>['has']>} */
+var $mapHas;
+if ($Map) {
+	$mapGet = uncurryThis($Map.prototype.get);
+	$mapSet = uncurryThis($Map.prototype.set);
+	$mapHas = uncurryThis($Map.prototype.has);
+}
 
 /*
  * This function traverses the list returning the node corresponding to the given key.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var inspect = require('object-inspect');
 
-var $TypeError = TypeError;
+var $TypeError = require('es-errors/type');
 var $WeakMap = typeof WeakMap === 'undefined' ? undefined : WeakMap;
 var $Map = typeof Map === 'undefined' ? undefined : Map;
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,15 @@ var $Map = typeof Map === 'undefined' ? undefined : Map;
 
 var $bind = Function.prototype.bind;
 var $call = Function.prototype.call;
-var uncurryThis = $bind.bind($call);
+var uncurryThis = $bind
+	? $bind.bind($call)
+	// @ts-ignore
+	: function uncurryThis(f) {
+		return function () {
+			// @ts-ignore
+			return $call.apply(f, arguments);
+		};
+	};
 
 /**
  * @template {(this: unknown, ...args: any[]) => unknown} T

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"typescript": "next"
 	},
 	"dependencies": {
+		"es-errors": "^1.3.0",
 		"object-inspect": "^1.13.1"
 	},
 	"auto-changelog": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,5 @@
 	},
 	"engines": {
 		"node": ">= 0.4"
-	},
-	"packageManager": "npm@10.8.1+sha1.1f1cb1305cd9246b9efe07d8629874df23157a2f"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -78,5 +78,6 @@
 	},
 	"engines": {
 		"node": ">= 0.4"
-	}
+	},
+	"packageManager": "npm@10.8.1+sha1.1f1cb1305cd9246b9efe07d8629874df23157a2f"
 }

--- a/package.json
+++ b/package.json
@@ -61,9 +61,6 @@
 		"typescript": "next"
 	},
 	"dependencies": {
-		"call-bind": "^1.0.7",
-		"es-errors": "^1.3.0",
-		"get-intrinsic": "^1.2.4",
 		"object-inspect": "^1.13.1"
 	},
 	"auto-changelog": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"extends": "@ljharb/tsconfig",
+	"exclude": ["coverage"],
 	"compilerOptions": {
 		"target": "es2021",																	/* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
 	},


### PR DESCRIPTION
Removes get-intrinsic/call-bind as dependencies without changing the supported runtimes or the robustness of the package assuming side-channel is required before WeakMap/Map/Function are tampered with.
I wasn't able to test in node@0.4 but I tested in node@0.8 (no Map or WeakMap) and everything worked fine there.

Also I fixed the lint.